### PR TITLE
Add SDL2_mixer

### DIFF
--- a/make_SDL_Libs.sh
+++ b/make_SDL_Libs.sh
@@ -7,5 +7,33 @@ export LDFLAGS
 export PKG_CONFIG_PATH
 if [ ! -f config.guess ]; then wget --continue http://git.savannah.gnu.org/cgit/config.git/plain/config.guess; fi
 if [ ! -f config.sub ]; then wget --continue http://git.savannah.gnu.org/cgit/config.git/plain/config.sub; fi
-for SCRIPT in scripts/*.sh; do "$SCRIPT" || { echo "$SCRIPT: Failed."; exit 1; } done
 
+## Fetch the build scripts.
+BUILD_SCRIPTS=`ls scripts/*.sh | sort`
+
+## If specific steps were requested...
+if [ $1 ]; then
+
+  ## Find the requested build scripts.
+  REQUESTS=""
+
+  for STEP in $@; do
+    SCRIPT=""
+    for i in $BUILD_SCRIPTS; do
+      if [ `basename $i | cut -d'_' -f1` -eq $STEP ]; then
+        SCRIPT=$i
+        break
+      fi
+    done
+
+    [ -z $SCRIPT ] && { echo "ERROR: unknown step $STEP"; exit 1; }
+
+    REQUESTS="$REQUESTS $SCRIPT"
+  done
+
+  ## Only run the requested build scripts
+  BUILD_SCRIPTS="$REQUESTS"
+fi
+
+## Run the build scripts.
+for SCRIPT in $BUILD_SCRIPTS; do "$SCRIPT" || { echo "$SCRIPT: Failed."; exit 1; } done

--- a/scripts/005_SDL2_mixer-2.0.4.sh
+++ b/scripts/005_SDL2_mixer-2.0.4.sh
@@ -1,0 +1,23 @@
+wget --continue http://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-2.0.4.tar.gz || { exit 1; }
+
+tar xfvz ./SDL2_mixer-2.0.4.tar.gz || { exit 1; }
+
+cd SDL2_mixer-2.0.4 || { exit 1; }
+
+cp ../config.sub ../config.guess build-scripts/ || { exit 1; }
+
+#cat ../patches/SDL2_mixer-2.0.4.patch | patch -p1 || { exit 1; }
+
+LIBMIKMOD_CONFIG="$PS3DEV/portlibs/ppu/bin/libmikmod-config"
+export LIBMIKMOD_CONFIG
+./configure --prefix="$PS3DEV/portlibs/ppu" --host=powerpc64-ps3-elf \
+	--disable-sdltest \
+	--with-sdl-exec-prefix="$PS3DEV/portlibs/ppu" \
+	--disable-shared \
+	--disable-music-cmd \
+	--disable-music-ogg-shared \
+	--disable-music-mp3 \
+	--disable-music-flac \
+    	|| { exit 1; }
+
+make && make install || { exit 1; }


### PR DESCRIPTION
This PR just adds a script to build and install SDL2_mixer. Depends on https://github.com/ps3dev/ps3libraries/pull/37 which is where the SDL2 port was added. The SDL2 port for PS3 is this one, based on the SDL1.3 port: https://github.com/sergiou87/SDL2_PSL1GHT

It also adds the ability to select which specific dependencies install instead of having to install all of them every time.